### PR TITLE
docs: update readme: front-end API and structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,33 +6,43 @@ This makes it super simple to use Unleash from any Flutter app.
 
 ## How to use the client as a module
 
-**Step 1: Unleash Proxy**
-
-Before you can use this Unleash SDK you need set up a Unleash Proxy instance. [Read more about the Unleash Proxy](https://docs.getunleash.io/sdks/unleash-proxy).
-
-
-**Step 2: Install**
+### Step 1: Installation
 
 ```
 flutter pub add unleash_proxy_client_flutter
 ```
 
-**Step 3: Initialize the SDK**
+### Step 2: Initialize the SDK
 
-You need to have a Unleash-hosted instance, and the proxy need to be enabled. In addition you will need a proxy-specific `clientKey` in order to connect  to the Unleash-hosted Proxy.
+---
+
+💡 **TIP**: As a client-side SDK, this SDK requires you to connect to either an Unleash proxy or to the Unleash front-end API. Refer to the [connection options section](#connection-options) for more information.
+
+---
+
+Configure the client according to your needs. The following example provides only the required options. Refer to [the section on available options](#available-options) for the full list.
+
 
 ```dart
 import 'package:unleash_proxy_client_flutter/unleash_proxy_client_flutter.dart';
 
 final unleash = UnleashClient(
-    url: Uri.parse('https://app.unleash-hosted.com/demo/api/proxy'),
-    clientKey: 'proxy-123',
+    url: Uri.parse('https://<your-unleash-instance>/api/frontend'),
+    clientKey: '<your-client-side-token>',
     appName: 'my-app');
 ```
 
-**Step 4: Listen for when the client is ready**
+#### Connection options
 
-You shouldn't start working with the client immediately. It's recommended to wait for `ready` or `initialized` event:
+To connect this SDK to your Unleash instance's [front-end API](https://docs.getunleash.io/reference/front-end-api), use the URL to your Unleash instance's front-end API (`<unleash-url>/api/frontend`) as the `url` parameter. For the `clientKey` parameter, use a `FRONTEND` token generated from your Unleash instance. Refer to the [_how to create API tokens_](https://docs.getunleash.io/how-to/how-to-create-api-tokens) guide for the necessary steps.
+
+To connect this SDK to the [Unleash proxy](https://docs.getunleash.io/reference/unleash-proxy), use the proxy's URL and a [proxy client key](https://docs.getunleash.io/reference/api-tokens-and-client-keys#proxy-client-keys). The [_configuration_ section of the Unleash proxy docs](https://docs.getunleash.io/reference/unleash-proxy#configuration) contains more info on how to configure client keys for your proxy.
+
+
+### Step 3: Let the client synchronize
+
+You should wait for the client's `ready` or `initialized` events before you start working with it. Before it's ready, the client might not report the correct state for your features.
+
 
 ```dart
 unleash.on('ready', (_) {
@@ -46,7 +56,34 @@ unleash.on('ready', (_) {
 
 The difference between the events is [explained below](#available-events).
 
-**Step 5: Start polling the Unleash Proxy**
+### Step 4: Check feature toggle states
+
+Once the client is ready, you can start checking features in your application. Use the `isEnabled` method to check the state of any feature you want:
+
+```dart
+unleash.isEnabled('proxy.demo');
+```
+
+You can use the `getVariant` method to get the variant of an **enabled feature that has variants**. If the feature is disabled or if it has no variants, then you will get back the [**disabled variant**](https://docs.getunleash.io/reference/feature-toggle-variants#the-disabled-variant)
+
+```dart
+final variant = unleash.getVariant('proxy.demo');
+
+if(variant.name == 'blue') {
+ // something with variant blue...
+}
+```
+
+#### Updating the Unleash context
+
+The [Unleash context](https://docs.getunleash.io/reference/unleash-context) is used to evaluate features against attributes of a the current user. To update and configure the Unleash context in this SDK, use the `updateContext` and `setContextField` methods.
+
+The context you set in your app will be passed along to the Unleash proxy or the front-end API as query parameters for feature evaluation.
+
+The `updateContext` method will replace the entire
+(mutable part) of the Unleash context with the data that you pass in.
+
+The `setContextField` method only acts on the property that you choose. It does not affect any other properties of the Unleash context.
 
 ```dart
 // Used to set the context fields, shared with the Unleash Proxy. This 
@@ -55,19 +92,6 @@ unleash.updateContext(UnleashContext(userId: '1233'));
 
 // Used to update a single field on the Unleash Context.
 unleash.setContextField('userId', '4141');
-
-// Send the initial fetch towards the Unleash Proxy and starts the background polling
-unleash.start();
-```
-
-**Step 6: Get toggle variant**
-
-```dart
-final variant = unleash.getVariant('proxy.demo');
-
-if(variant.name == 'blue') {
- // something with variant blue...
-}
 ```
 
 ### Available options


### PR DESCRIPTION
This change updates the readme in the following ways:
- Use the front-end API connection details as the primary example
- Add more info about connecting to the front-end API and the proxy, including links to docs
- Use a header structure to organize sections of the how-to guides instead of bolded text.

A lot of this is lifted from the JS proxy readme, so I'd like some help to make sure that it is correct before it goes in.
