### PR TITLE
fix!: set clientstate before emitting event

### DIFF
--- a/lib/unleash_proxy_client_flutter.dart
+++ b/lib/unleash_proxy_client_flutter.dart
@@ -163,15 +163,15 @@ class UnleashClient extends EventEmitter {
       toggles = togglesInStorage;
     }
 
-    emit(initializedEvent);
     clientState = ClientState.initialized;
+    emit(initializedEvent);
 
     if (bootstrap != null && (bootstrapOverride || togglesInStorage.isEmpty)) {
       await actualStorageProvider.save(
           storageWithApp(appName, storageKey), stringifyToggles(bootstrap));
       toggles = bootstrap;
-      emit(readyEvent);
       clientState = ClientState.ready;
+      emit(readyEvent);
     }
   }
 
@@ -310,8 +310,8 @@ class UnleashClient extends EventEmitter {
     await _fetchToggles();
 
     if (clientState != ClientState.ready) {
-      emit(readyEvent);
       clientState = ClientState.ready;
+      emit(readyEvent);
     }
 
     if (!disableRefresh) {

--- a/test/unleash_proxy_client_flutter_test.dart
+++ b/test/unleash_proxy_client_flutter_test.dart
@@ -1051,6 +1051,31 @@ void main() {
     expect(count, 1);
   });
 
+  test('clientState should be ready when ready event is emitted', () async {
+    final getMock = GetMock();
+    final unleash = UnleashClient(
+        url: url,
+        clientKey: 'proxy-123',
+        appName: 'flutter-test',
+        bootstrap: {
+          'flutter-on': ToggleConfig(
+              enabled: true,
+              impressionData: false,
+              variant: Variant(enabled: true, name: 'variant-name'))
+        },
+        storageProvider: InMemoryStorageProvider(),
+        fetcher: getMock);
+
+    unleash.on('initialized', (_) {
+      expect(unleash.clientState, ClientState.initialized);
+    });
+    unleash.on('ready', (_) {
+      expect(unleash.clientState, ClientState.ready);
+    });
+
+    await unleash.start();
+  });
+
   test('API should override bootstrap after fetching data', () async {
     final getMock = GetMock();
     final unleash = UnleashClient(


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
Currently the sdk emits the `initialized` and `ready` events before the clientState is set accordingly.
This moves the `clientState = ` calls to *before* the emits, as it makes more sense if we want to accurately describe the state.
Makes it easier to have generic handlers, e.g.
```
  client.on('update', (data) => _update());
  client.on('ready', (data) => _update());
  _update() {
    const defaults = FeatureFlags();
    final ready = client.clientState == ClientState.ready;
    state = FeatureFlags(
      signup: !ready ? defaults.signup : client.isEnabled('public-signup'),
    );
  }
```