### PR TITLE
feat: send appName

### DIFF
--- a/lib/unleash_context.dart
+++ b/lib/unleash_context.dart
@@ -8,11 +8,6 @@ class UnleashContext {
   UnleashContext({this.userId, this.sessionId, this.remoteAddress, properties})
       : properties = properties ?? {};
 
-  String toQueryParams() {
-    final result = Uri(queryParameters: toMap()).query;
-    return result.isNotEmpty ? '?$result' : '';
-  }
-
   Map<String, String> toMap() {
     final userId = this.userId;
     final remoteAddress = this.remoteAddress;

--- a/lib/unleash_proxy_client_flutter.dart
+++ b/lib/unleash_proxy_client_flutter.dart
@@ -189,8 +189,14 @@ class UnleashClient extends EventEmitter {
         headers['If-None-Match'] = etag;
       }
 
-      final request = http.Request(
-          'GET', Uri.parse('${url.toString()}${context.toQueryParams()}'));
+      final uri = url.replace(
+        queryParameters: {
+          ...url.queryParameters,
+          ...context.toMap(),
+          'appName': appName,
+        },
+      );
+      final request = http.Request('GET', uri);
       request.headers.addAll(headers);
       final response = await fetcher(request);
 


### PR DESCRIPTION
## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

I was sending appName manually via `properties` on UnleashContext but this was broken by #20, so this fixes for those of us who needs to send appName.

It also changes how the query parameters are constructed to be more idiomatic for dart, and safer.

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->

I didn't add it into UnleashContext because it's exposed to library users and it could be confusing because appName is already passed to UnleashClient, and it can't be changed there.

There might be other missing properties you should look into adding, like `environment`?