### PR TITLE
fix: add type for the 'properties' parameter

### DIFF
--- a/lib/unleash_context.dart
+++ b/lib/unleash_context.dart
@@ -5,7 +5,7 @@ class UnleashContext {
   String? remoteAddress;
   Map<String, String> properties;
 
-  UnleashContext({this.userId, this.sessionId, this.remoteAddress, properties})
+  UnleashContext({this.userId, this.sessionId, this.remoteAddress, Map<String, String>? properties})
       : properties = properties ?? {};
 
   String toQueryParams() {


### PR DESCRIPTION


## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

`properties` was missing a type, so it was `dynamic` 