### PR TITLE
chore: Updated uuid to 4.2.2 and shared_preferences to 2.2.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,8 @@ dependencies:
     sdk: flutter
   http: '>=0.13.5 <2.0.0'
   events_emitter: ^0.5.2
-  shared_preferences: ^2.0.15
-  uuid: ^3.0.7
+  shared_preferences: ^2.2.2
+  uuid: ^4.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## About the changes
- Updated 'uuid' dependency from 3.0.7 to 4.2.2.
- Updated 'shared_preferences' dependency from 2.0.15 to 2.2.2.

### Important files
- pubspec.yaml

## Discussion points
Are there any issues with this dependencies update?
