### PR TITLE
feat: add default value param for isEnabled

### DIFF
--- a/lib/unleash_proxy_client_flutter.dart
+++ b/lib/unleash_proxy_client_flutter.dart
@@ -373,9 +373,9 @@ class UnleashClient extends EventEmitter {
     }
   }
 
-  bool isEnabled(String featureName) {
+  bool isEnabled(String featureName, {bool defaultValue = false}) {
     final toggle = toggles[featureName];
-    final enabled = toggle?.enabled ?? false;
+    final enabled = toggle?.enabled ?? defaultValue;
     metrics.count(featureName, enabled);
 
     _emitImpression(featureName, 'isEnabled');

--- a/test/unleash_proxy_client_flutter_test.dart
+++ b/test/unleash_proxy_client_flutter_test.dart
@@ -329,6 +329,19 @@ void main() {
     expect(getMock.calledTimes, 1);
   });
 
+  test('can fetch initial toggles with default value', () async {
+    final getMock = GetMock();
+    final unleash = UnleashClient(
+        url: url,
+        clientKey: 'proxy-123',
+        appName: 'flutter-test',
+        storageProvider: InMemoryStorageProvider(),
+        fetcher: getMock);
+
+    expect(unleash.isEnabled('flutter-on', defaultValue: true), true);
+    expect(unleash.isEnabled('flutter-off'), false);
+  });
+
   test('can store toggles in memory storage', () async {
     final getMock = GetMock();
     final storageProvider = InMemoryStorageProvider();


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
Currently, when a feature toggle is not fetched or an error occurs, it defaults to false. This pull request aims to enhance the `isEnabled` function by introducing functionality that allows setting a customizable default value in such scenarios.

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->
