### PR TITLE
feat: prevent fetch on init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.0
+
+* Feat: experimental support for skip fetch toggles on start
+
 ## 1.7.0
 
 * Feat: manual control over updateToggles and sendMetrics

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ In this case, it becomes your responsibility to call `updateToggles` and/or `sen
 
 If you start multiple clients sharing the same storage provider (e.g. a default `SharedPreferencesStorageProvider`) you might want to skip fetching toggles on start for all but one of the clients. 
 This can be achieved by setting the `togglesStorageTTL` to a non-zero value. 
-E.g in the example below, the toggles will be considered valid for 10 seconds and will not be fetched on start if they already exist in storageq.
+E.g in the example below, the toggles will be considered valid for 10 seconds and will not be fetched on start if they already exist in storage.
 
 ```dart
     final anotherUnleash = UnleashClient(

--- a/README.md
+++ b/README.md
@@ -204,12 +204,13 @@ In this case, it becomes your responsibility to call `updateToggles` and/or `sen
 
 If you start multiple clients sharing the same storage provider (e.g. a default `SharedPreferencesStorageProvider`) you might want to skip fetching toggles on start for all but one of the clients. 
 This can be achieved by setting the `togglesStorageTTL` to a non-zero value. 
-E.g in the example below, the toggles will be considered valid for 10 seconds and will not be fetched on start if they already exist in storage.
+E.g in the example below, the toggles will be considered valid for 60 seconds and will not be fetched on start if they already exist in storage.
+We recommend to set `togglesStorageTTL` to a value greater than the `refreshInterval`.
 
 ```dart
     final anotherUnleash = UnleashClient(
         // ...
-        experimental: const ExperimentalConfig(togglesStorageTTL: 10)
+        experimental: const ExperimentalConfig(togglesStorageTTL: 60)
     );
 ```
 

--- a/README.md
+++ b/README.md
@@ -116,23 +116,24 @@ unleash.setContextFields({'userId': '4141'});
 
 The Unleash SDK takes the following options:
 
-| option            | required | default                   | description                                                                                                                                      |
-|-------------------|----------|---------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
-| url               | yes | n/a                       | The Unleash Proxy URL to connect to. E.g.: `https://examples.com/proxy`                                                                         |
-| clientKey         | yes | n/a                       | The Unleash Proxy Secret to be used                                                                                                             | 
-| appName           | yes | n/a                       | The name of the application using this SDK. Will be used as part of the metrics sent to Unleash Proxy. Will also be part of the Unleash Context. | 
-| refreshInterval   | no | 30                        | How often, in seconds, the SDK should check for updated toggle configuration. If set to 0 will disable checking for updates                 |
-| disableRefresh    | no | false                     | If set to true, the client will not check for updated toggle configuration                                                                |
-| metricsInterval   | no | 30                        | How often, in seconds, the SDK should send usage metrics back to Unleash Proxy                                                              | 
-| disableMetrics    | no | false                     | Set this option to `true` if you want to disable usage metrics
+| option            | required | default                            | description                                                                                                                                      |
+|-------------------|----------|------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| url               | yes | n/a                                | The Unleash Proxy URL to connect to. E.g.: `https://examples.com/proxy`                                                                         |
+| clientKey         | yes | n/a                                | The Unleash Proxy Secret to be used                                                                                                             | 
+| appName           | yes | n/a                                | The name of the application using this SDK. Will be used as part of the metrics sent to Unleash Proxy. Will also be part of the Unleash Context. | 
+| refreshInterval   | no | 30                                 | How often, in seconds, the SDK should check for updated toggle configuration. If set to 0 will disable checking for updates                 |
+| disableRefresh    | no | false                              | If set to true, the client will not check for updated toggle configuration                                                                |
+| metricsInterval   | no | 30                                 | How often, in seconds, the SDK should send usage metrics back to Unleash Proxy                                                              | 
+| disableMetrics    | no | false                              | Set this option to `true` if you want to disable usage metrics
 | storageProvider   | no | `SharedPreferencesStorageProvider` | Allows you to inject a custom storeProvider                                                                              |
-| bootstrap         | no | `[]`                      | Allows you to bootstrap the cached feature toggle configuration.                                                                               | 
-| bootstrapOverride | no| `true`                    | Should the bootstrap automatically override cached data in the local-storage. Will only be used if bootstrap is not an empty array.     |
-| headerName        | no| `Authorization`           | Provides possiblity to specify custom header that is passed to Unleash / Unleash Proxy with the `clientKey` |
-| customHeaders     | no| `{}`                      | Additional headers to use when making HTTP requests to the Unleash proxy. In case of name collisions with the default headers, the `customHeaders` value will be used. |
-| impressionDataAll | no| `false` | Allows you to trigger "impression" events for **all** `getToggle` and `getVariant` invocations. This is particularly useful for "disabled" feature toggles that are not visible to frontend SDKs. |
+| bootstrap         | no | `null`                             | Allows you to bootstrap the cached feature toggle configuration.                                                                               | 
+| bootstrapOverride | no| `true`                             | Should the bootstrap automatically override cached data in the local-storage. Will only be used if bootstrap is not an empty array.     |
+| headerName        | no| `Authorization`                    | Provides possiblity to specify custom header that is passed to Unleash / Unleash Proxy with the `clientKey` |
+| customHeaders     | no| `{}`                               | Additional headers to use when making HTTP requests to the Unleash proxy. In case of name collisions with the default headers, the `customHeaders` value will be used. |
+| impressionDataAll | no| `false`                            | Allows you to trigger "impression" events for **all** `getToggle` and `getVariant` invocations. This is particularly useful for "disabled" feature toggles that are not visible to frontend SDKs. |
 | fetcher           | no | `http.get`                         | Allows you to define your own **fetcher**. Can be used to add certificate pinning or additional http behavior. |
 | poster            | no | `http.post`                        | Allows you to define your own **poster**. Can be used to add certificate pinning or additional http behavior.  |
+| experimental      | no | `null`                             | Enabling optional experimentation. `togglesStorageTTL` : How long (Time To Live), in seconds, the toggles in storage are considered valid and should not be fetched on start. If set to 0 will disable expiration checking and will be considered always expired.
 ### Listen for updates via the events_emitter
 
 The client is also an event emitter. This means that your code can subscribe to updates from the client.
@@ -174,7 +175,7 @@ This is also useful if you require the toggles to be in a certain state immediat
 
 ### How to use it ?
 Add a `bootstrap` attribute when create a new `UnleashClient`.  
-There's also a `bootstrapOverride` attribute which is by default is `true`.
+There's also a `bootstrapOverride` attribute which by default is `true`.
 
 ```dart
 final unleash = UnleashClient(
@@ -198,6 +199,19 @@ final unleash = UnleashClient(
 
 You can opt out of the Unleash feature flag auto-refresh mechanism and metrics update by settings the `refreshInterval` and/or `metricsInterval` options to `0`.
 In this case, it becomes your responsibility to call `updateToggles` and/or `sendMetrics` methods.
+
+## Experimental: skip fetching toggles on start
+
+If you start multiple clients sharing the same storage provider (e.g. a default `SharedPreferencesStorageProvider`) you might want to skip fetching toggles on start for all but one of the clients. 
+This can be achieved by setting the `togglesStorageTTL` to a non-zero value. 
+E.g in the example below, the toggles will be considered valid for 10 seconds and will not be fetched on start if they already exist in storageq.
+
+```dart
+    final anotherUnleash = UnleashClient(
+        // ...
+        experimental: const ExperimentalConfig(togglesStorageTTL: 10)
+    );
+```
 
 ## Release guide
 * Run tests: `flutter test`

--- a/lib/last_update_terms.dart
+++ b/lib/last_update_terms.dart
@@ -1,0 +1,25 @@
+class LastUpdateTerms {
+  String key;
+  int timestamp;
+
+  LastUpdateTerms({required this.key, required this.timestamp});
+
+  @override
+  String toString() {
+    return '{key: $key, timestamp: $timestamp}';
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'key': key,
+      'timestamp': timestamp,
+    };
+  }
+
+  factory LastUpdateTerms.fromJson(Map<String, dynamic> json) {
+    return LastUpdateTerms(
+      key: json['key'],
+      timestamp: json['timestamp'],
+    );
+  }
+}

--- a/lib/unleash_context.dart
+++ b/lib/unleash_context.dart
@@ -30,6 +30,14 @@ class UnleashContext {
     return params;
   }
 
+  // TODO: consider different hashing function that is stable between sessions
+  String getKey() {
+    final propertiesHash = Object.hashAll(
+        properties.entries.map((e) => Object.hash(e.key, e.value)));
+    return Object.hash(userId, sessionId, remoteAddress, propertiesHash)
+        .toString();
+  }
+
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;

--- a/lib/unleash_context.dart
+++ b/lib/unleash_context.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 /// https://docs.getunleash.io/reference/unleash-context
 class UnleashContext {
   String? userId;
@@ -30,12 +32,25 @@ class UnleashContext {
     return params;
   }
 
-  // TODO: consider different hashing function that is stable between sessions
   String getKey() {
-    final propertiesHash = Object.hashAll(
-        properties.entries.map((e) => Object.hash(e.key, e.value)));
-    return Object.hash(userId, sessionId, remoteAddress, propertiesHash)
-        .toString();
+    final buffer = StringBuffer();
+
+    if (userId != null) {
+      buffer.write('userId=$userId;');
+    }
+    if (sessionId != null) {
+      buffer.write('sessionId=$sessionId;');
+    }
+    if (remoteAddress != null) {
+      buffer.write('remoteAddress=$remoteAddress;');
+    }
+
+    properties.forEach((key, value) {
+      buffer.write('$key=$value;');
+    });
+
+    final bytes = utf8.encode(buffer.toString());
+    return base64.encode(bytes);
   }
 
   @override

--- a/lib/unleash_proxy_client_flutter.dart
+++ b/lib/unleash_proxy_client_flutter.dart
@@ -201,7 +201,6 @@ class UnleashClient extends EventEmitter {
       await actualStorageProvider.save(
           storageWithApp(appName, storageKey), stringifyToggles(bootstrap));
       toggles = bootstrap;
-
       clientState = ClientState.ready;
       emit(readyEvent);
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A Flutter/Dart client that can be used together with the unleash-pr
 homepage: https://github.com/Unleash/unleash_proxy_client_flutter
 repository: https://github.com/Unleash/unleash_proxy_client_flutter
 issue_tracker: https://github.com/Unleash/unleash_proxy_client_flutter
-version: 1.7.0
+version: 1.8.0
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/test/unleash_context_test.dart
+++ b/test/unleash_context_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:unleash_proxy_client_flutter/unleash_context.dart';
+
+void main() {
+  test('returns consistent key for same values', () {
+    final context1 = UnleashContext(
+        userId: 'user1',
+        sessionId: 'session1',
+        remoteAddress: '192.168.1.1',
+        properties: {'key1': 'value1'}
+    );
+
+    expect(context1.getKey(), "dXNlcklkPXVzZXIxO3Nlc3Npb25JZD1zZXNzaW9uMTtyZW1vdGVBZGRyZXNzPTE5Mi4xNjguMS4xO2tleTE9dmFsdWUxOw==");
+  });
+}

--- a/test/unleash_context_test.dart
+++ b/test/unleash_context_test.dart
@@ -7,9 +7,9 @@ void main() {
         userId: 'user1',
         sessionId: 'session1',
         remoteAddress: '192.168.1.1',
-        properties: {'key1': 'value1'}
-    );
+        properties: {'key1': 'value1'});
 
-    expect(context1.getKey(), "dXNlcklkPXVzZXIxO3Nlc3Npb25JZD1zZXNzaW9uMTtyZW1vdGVBZGRyZXNzPTE5Mi4xNjguMS4xO2tleTE9dmFsdWUxOw==");
+    expect(context1.getKey(),
+        "dXNlcklkPXVzZXIxO3Nlc3Npb25JZD1zZXNzaW9uMTtyZW1vdGVBZGRyZXNzPTE5Mi4xNjguMS4xO2tleTE9dmFsdWUxOw==");
   });
 }


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Prevent fetching flags on init when storage has recent data (TTL not expired). This is a port of JS version https://github.com/Unleash/unleash-proxy-client-js/pull/224

Important:
* I'm using base64 encoding instead of sha256 hashing as in the JS version. It doesn't require any crypto libraries and we still store the flags in storage as plain text

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
