### PR TITLE
fix: skip initial fetch with context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.2
+
+* Fix: Skip initial toggles fetch when using updateContext or setContextFields
+
 ## 1.9.1
 
 * Chore: Upgrade event_emitter version

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:unleash_proxy_client_flutter/unleash_proxy_client_flutter.dart';
+import 'package:unleash_proxy_client_flutter/unleash_context.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -41,8 +42,12 @@ class _MyHomePageState extends State<MyHomePage> {
     var unleash = UnleashClient(
         url: Uri.parse('https://sandbox.getunleash.io/enterprise/api/frontend'),
         clientKey: 'SDKIntegration:development.f0474f4a37e60794ee8fb00a4c112de58befde962af6d5055b383ea3',
-        refreshInterval: 30,
+        refreshInterval: 10,
+        experimental: const ExperimentalConfig(togglesStorageTTL: 60),
         appName: 'example-flutter-app');
+    unleash.updateContext(UnleashContext(
+        userId: '123',
+        ));
     void updateCounterEnabled(_) {
       final counterEnabled = unleash.isEnabled('counter');
       setState(() {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -355,7 +355,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.9.0"
+    version: "1.9.2"
   uuid:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A Flutter/Dart client that can be used together with the unleash-pr
 homepage: https://github.com/Unleash/unleash_proxy_client_flutter
 repository: https://github.com/Unleash/unleash_proxy_client_flutter
 issue_tracker: https://github.com/Unleash/unleash_proxy_client_flutter
-version: 1.9.1
+version: 1.9.2
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/test/unleash_proxy_client_flutter_test.dart
+++ b/test/unleash_proxy_client_flutter_test.dart
@@ -454,6 +454,68 @@ void main() {
     expect(anotherGetMock.calledTimes, 1);
   });
 
+  test('skip initial fetch when context is identical with updateContext',
+      () async {
+    final getMock = GetMock();
+    final sharedStorageProvider = InMemoryStorageProvider();
+    final unleash = UnleashClient(
+        url: url,
+        clientKey: 'proxy-123',
+        appName: 'flutter-test',
+        storageProvider: sharedStorageProvider,
+        fetcher: getMock,
+        experimental: const ExperimentalConfig(togglesStorageTTL: 10));
+    unleash.updateContext(UnleashContext(userId: '123'));
+
+    await unleash.start();
+
+    final anotherGetMock = GetMock();
+    final anotherUnleash = UnleashClient(
+      url: url,
+      clientKey: 'proxy-123',
+      appName: 'flutter-test',
+      storageProvider: sharedStorageProvider,
+      fetcher: anotherGetMock,
+      experimental: const ExperimentalConfig(togglesStorageTTL: 10),
+    );
+    anotherUnleash.updateContext(UnleashContext(userId: '123'));
+
+    await anotherUnleash.start();
+
+    expect(anotherGetMock.calledTimes, 0);
+  });
+
+  test('skip initial fetch when context is identical with setContextFields',
+      () async {
+    final getMock = GetMock();
+    final sharedStorageProvider = InMemoryStorageProvider();
+    final unleash = UnleashClient(
+        url: url,
+        clientKey: 'proxy-123',
+        appName: 'flutter-test',
+        storageProvider: sharedStorageProvider,
+        fetcher: getMock,
+        experimental: const ExperimentalConfig(togglesStorageTTL: 10));
+    unleash.setContextFields({'userId': '123'});
+
+    await unleash.start();
+
+    final anotherGetMock = GetMock();
+    final anotherUnleash = UnleashClient(
+      url: url,
+      clientKey: 'proxy-123',
+      appName: 'flutter-test',
+      storageProvider: sharedStorageProvider,
+      fetcher: anotherGetMock,
+      experimental: const ExperimentalConfig(togglesStorageTTL: 10),
+    );
+    anotherUnleash.setContextFields({'userId': '123'});
+
+    await anotherUnleash.start();
+
+    expect(anotherGetMock.calledTimes, 0);
+  });
+
   test('do not skip initial fetch when TTL exceeded', () async {
     final getMock = GetMock();
     final sharedStorageProvider = InMemoryStorageProvider();


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

We should skip initial fetch when TTL hasn't expired. This worked fine when you didn't use updateContext or setContextFields. This PR also makes sure that custom context is respected.


### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
