### PR TITLE
fix: stop metrics timer on stop client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.6
+
+* Fix: stop metrics timer on client stop
+
 ## 1.9.5
 
 * Fix: add variant data to impression event

--- a/lib/metrics.dart
+++ b/lib/metrics.dart
@@ -87,6 +87,13 @@ class Metrics {
     });
   }
 
+  stop() {
+    final Timer? timer = this.timer;
+    if (timer != null && timer.isActive) {
+      timer.cancel();
+    }
+  }
+
   void count(String name, bool enabled) {
     if (disableMetrics) {
       return;

--- a/lib/unleash_proxy_client_flutter.dart
+++ b/lib/unleash_proxy_client_flutter.dart
@@ -157,7 +157,7 @@ class UnleashClient extends EventEmitter {
       this.customHeaders = const {},
       this.impressionDataAll = false,
       // bump on each release, overwrite in tests, do not change in client code
-      this.sdkName = 'unleash-client-flutter:1.9.5',
+      this.sdkName = 'unleash-client-flutter:1.9.6',
       this.experimental}) {
     _init();
     metrics = Metrics(

--- a/lib/unleash_proxy_client_flutter.dart
+++ b/lib/unleash_proxy_client_flutter.dart
@@ -482,6 +482,7 @@ class UnleashClient extends EventEmitter {
     if (timer != null && timer.isActive) {
       timer.cancel();
     }
+    metrics.stop();
   }
 
   void _emitImpression(String featureName, String type) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A Flutter/Dart client that can be used together with the unleash-pr
 homepage: https://github.com/Unleash/unleash_proxy_client_flutter
 repository: https://github.com/Unleash/unleash_proxy_client_flutter
 issue_tracker: https://github.com/Unleash/unleash_proxy_client_flutter
-version: 1.9.5
+version: 1.9.6
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/test/unleash_proxy_client_flutter_test.dart
+++ b/test/unleash_proxy_client_flutter_test.dart
@@ -788,25 +788,37 @@ void main() {
   test('stopping client should cancel the timer', () {
     fakeAsync((async) {
       final getMock = GetMock();
+      var payload =
+      '''{start: 2022-12-21T14:18:38.953834, stop: 2022-12-21T14:18:48.953834, toggles: {}}''';
+      final postMock = PostMock(payload: payload, status: 200, headers: {});
       final unleash = UnleashClient(
           url: url,
           clientKey: 'proxy-123',
           appName: 'flutter-test',
           refreshInterval: 10,
+          metricsInterval: 10,
           storageProvider: InMemoryStorageProvider(),
-          fetcher: getMock);
+          fetcher: getMock,
+          poster: postMock
+      );
 
       unleash.start();
+      unleash.isEnabled('flutter-on');
       async.elapse(const Duration(seconds: 10));
       expect(getMock.calledTimes, 2);
+      expect(postMock.calledTimes, 1);
       // first stop cancels the timer
       unleash.stop();
+      unleash.isEnabled('flutter-on');
       async.elapse(const Duration(seconds: 10));
       expect(getMock.calledTimes, 2);
+      expect(postMock.calledTimes, 1);
       // second stop should be no-op
       unleash.stop();
+      unleash.isEnabled('flutter-on');
       async.elapse(const Duration(seconds: 10));
       expect(getMock.calledTimes, 2);
+      expect(postMock.calledTimes, 1);
     });
   });
 

--- a/test/unleash_proxy_client_flutter_test.dart
+++ b/test/unleash_proxy_client_flutter_test.dart
@@ -789,7 +789,7 @@ void main() {
     fakeAsync((async) {
       final getMock = GetMock();
       var payload =
-      '''{start: 2022-12-21T14:18:38.953834, stop: 2022-12-21T14:18:48.953834, toggles: {}}''';
+          '''{start: 2022-12-21T14:18:38.953834, stop: 2022-12-21T14:18:48.953834, toggles: {}}''';
       final postMock = PostMock(payload: payload, status: 200, headers: {});
       final unleash = UnleashClient(
           url: url,
@@ -799,8 +799,7 @@ void main() {
           metricsInterval: 10,
           storageProvider: InMemoryStorageProvider(),
           fetcher: getMock,
-          poster: postMock
-      );
+          poster: postMock);
 
       unleash.start();
       unleash.isEnabled('flutter-on');


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

When stopping Unleash client we should not only stop the fetching timer but also the metrics reporting timer.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
